### PR TITLE
Unicode

### DIFF
--- a/arff.py
+++ b/arff.py
@@ -73,7 +73,6 @@ def __encode_attribute(type_values):
 def __encode_values(values, attributes):
     '''Encode the values relative to their attributes'''
     result = []
-    print values, attributes
     for attr_func, val in zip(attributes, values):
         if val == None:
             result.append( '?' )


### PR DESCRIPTION
I changed a few calls to str() and some joins that were using raw strings, so that it can handle non-ASCII input when converting to an ARFF file. As part of that, there's a bunch of escaping for strings, since they are inherently very noisy, and since everything gets fed through that function (hence the prior '%s' if ' ' in s thing), there are new __encode methods that mimic the decode methods, and encode each value according to its attribute type.

Additionally, a couple changes to the loading of ARFF strings so they don't lose end characters by assuming a quote at the beginning of the value means it's a quoted string. This is probably not needed, since I don't think weka would even read strings like that.
