### PR TITLE
Support for decoding sparse data

### DIFF
--- a/arff.py
+++ b/arff.py
@@ -427,6 +427,10 @@ class ArffDecoder(object):
         '''
         values = next(csv.reader([s.strip(' ')]))
 
+        if values[0][0].strip(" ") == '{':
+            vdict = dict(map(lambda x: (int(x[0]), x[1]),[i.strip("{").strip("}").split(' ') for i in values]))
+            values = [unicode(vdict[i]) if i in vdict else unicode(0) for i in xrange(len(self._conversors))]
+
         if len(values) != len(self._conversors):
             raise BadDataFormat()
 

--- a/tests/test_decode_data.py
+++ b/tests/test_decode_data.py
@@ -32,3 +32,22 @@ class TestDecodeData(unittest.TestCase):
         self.assertEqual(result[1], expected[1])
         self.assertEqual(result[2], expected[2])
         self.assertEqual(result[3], expected[3])
+
+    def test_sparse(self):
+        '''Basic data instances.'''
+        decoder = self.get_decoder([
+            ConversorStub(unicode),
+            ConversorStub(float),
+            ConversorStub(int),
+            ConversorStub(unicode),
+            ConversorStub(float),
+            ConversorStub(int),
+        ])
+
+        fixture = u'{0 Iris,1 3.4,2 2}'
+        result = decoder._decode_data(fixture)
+        expected = [u'Iris', 3.4, 2, u'0', 0.0, 0]
+
+        self.assertEqual(len(result), len(expected))
+        for i in range(len(expected)):
+            self.assertEqual(result[i], expected[i])


### PR DESCRIPTION
I've implemented support for decoding sparse data by unsparsing it. I chose this way because most arff loaders can't support loading sparse files, so I need them to be able to use liac-arff to convert from sparse to non-sparse.
