### PR TITLE
Add Label Encoding

### DIFF
--- a/tests/test_conversor.py
+++ b/tests/test_conversor.py
@@ -94,9 +94,27 @@ class TestDecodeConversor(unittest.TestCase):
         expected = u'3.4'
         self.assertEqual(result, expected)
 
+    def test_encoded_nominal(self):
+        '''Convert nominal to encoded nominal value.'''
+        conversor = self.get_conversor('ENCODED_NOMINAL', [u'a', u'b', u'3.4'])
+
+        fixtures_and_expectations = [(u'a', 0), (u'b', 1), (u'3.4', 2)]
+        for fixture, expected in fixtures_and_expectations:
+            result = conversor(fixture)
+            self.assertEqual(result, expected)
+
     def test_null_value(self):
-        '''Values auch "?", or "".'''
+        '''Values such as "?", or "".'''
         conversor = self.get_conversor('NOMINAL', [u'a', u'b', u'3.4'])
+        result = conversor('?')
+        expected = None
+        self.assertEqual(result, expected)
+
+        result = conversor('')
+        expected = None
+        self.assertEqual(result, expected)
+
+        conversor = self.get_conversor('ENCODED_NOMINAL', [u'a', u'b', u'3.4'])
         result = conversor('?')
         expected = None
         self.assertEqual(result, expected)

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -32,33 +32,63 @@ rainy,71.0,91.0,TRUE,no
 % 
 '''
 
-OBJ = {
-    u'description':u'\nDESCRIPTION HERE\n',
-    u'relation': u'weather',
-    u'attributes': [
-        (u'outlook', [u'sunny', u'overcast', u'rainy']),
-        (u'temperature', 'REAL'),
-        (u'humidity', 'REAL'),
-        (u'windy', [u'TRUE', u'FALSE']),
-        (u'play', [u'yes', u'no'])
-    ],
-    u'data': [
-        [u'sunny', 85.0, 85.0, u'FALSE', u'no'],
-        [u'sunny', 80.0, 90.0, u'TRUE', u'no'],
-        [u'overcast', 83.0, 86.0, u'FALSE', u'yes'],
-        [u'rainy', 70.0, 96.0, u'FALSE', u'yes'],
-        [u'rainy', 68.0, 80.0, u'FALSE', u'yes'],
-        [u'rainy', 65.0, 70.0, u'TRUE', u'no'],
-        [u'overcast', 64.0, 65.0, u'TRUE', u'yes'],
-        [u'sunny', 72.0, 95.0, u'FALSE', u'no'],
-        [u'sunny', 69.0, 70.0, u'FALSE', u'yes'],
-        [u'rainy', 75.0, 80.0, u'FALSE', u'yes'],
-        [u'sunny', 75.0, 70.0, u'TRUE', u'yes'],
-        [u'overcast', 72.0, 90.0, u'TRUE', u'yes'],
-        [u'overcast', 81.0, 75.0, u'FALSE', u'yes'],
-        [u'rainy', 71.0, 91.0, u'TRUE', u'no']
+description = u'\nDESCRIPTION HERE\n'
+relation = u'weather'
+attributes = [
+    (u'outlook', [u'sunny', u'overcast', u'rainy']),
+    (u'temperature', 'REAL'),
+    (u'humidity', 'REAL'),
+    (u'windy', [u'TRUE', u'FALSE']),
+    (u'play', [u'yes', u'no'])
     ]
+data = [
+    [u'sunny', 85.0, 85.0, u'FALSE', u'no'],
+    [u'sunny', 80.0, 90.0, u'TRUE', u'no'],
+    [u'overcast', 83.0, 86.0, u'FALSE', u'yes'],
+    [u'rainy', 70.0, 96.0, u'FALSE', u'yes'],
+    [u'rainy', 68.0, 80.0, u'FALSE', u'yes'],
+    [u'rainy', 65.0, 70.0, u'TRUE', u'no'],
+    [u'overcast', 64.0, 65.0, u'TRUE', u'yes'],
+    [u'sunny', 72.0, 95.0, u'FALSE', u'no'],
+    [u'sunny', 69.0, 70.0, u'FALSE', u'yes'],
+    [u'rainy', 75.0, 80.0, u'FALSE', u'yes'],
+    [u'sunny', 75.0, 70.0, u'TRUE', u'yes'],
+    [u'overcast', 72.0, 90.0, u'TRUE', u'yes'],
+    [u'overcast', 81.0, 75.0, u'FALSE', u'yes'],
+    [u'rainy', 71.0, 91.0, u'TRUE', u'no']
+]
+encoded_data = [
+    [0, 85.0, 85.0, 1, 1],
+    [0, 80.0, 90.0, 0, 1],
+    [1, 83.0, 86.0, 1, 0],
+    [2, 70.0, 96.0, 1, 0],
+    [2, 68.0, 80.0, 1, 0],
+    [2, 65.0, 70.0, 0, 1],
+    [1, 64.0, 65.0, 0, 0],
+    [0, 72.0, 95.0, 1, 1],
+    [0, 69.0, 70.0, 1, 0],
+    [2, 75.0, 80.0, 1, 0],
+    [0, 75.0, 70.0, 0, 0],
+    [1, 72.0, 90.0, 0, 0],
+    [1, 81.0, 75.0, 1, 0],
+    [2, 71.0, 91.0, 0, 1]
+]
+
+OBJ = {
+    u'description': description,
+    u'relation': relation,
+    u'attributes': attributes,
+    u'data': data
 }
+
+ENCODED_OBJ = {
+    u'description': description,
+    u'relation': relation,
+    u'attributes': attributes,
+    u'data': encoded_data
+}
+
+
 
 
 class TestDecodeComment(unittest.TestCase):
@@ -71,6 +101,30 @@ class TestDecodeComment(unittest.TestCase):
 
         result = decoder.decode(ARFF)
         expected = OBJ
+
+        self.assertEqual(result['description'], expected['description'])
+        self.assertEqual(result['relation'], expected['relation'])
+
+        self.assertEqual(len(result['attributes']), len(expected['attributes']))
+        self.assertEqual(result['attributes'][0][0], expected['attributes'][0][0])
+        self.assertEqual(result['attributes'][0][1][0], expected['attributes'][0][1][0])
+        self.assertEqual(result['attributes'][0][1][1], expected['attributes'][0][1][1])
+        self.assertEqual(result['attributes'][0][1][2], expected['attributes'][0][1][2])
+
+        self.assertEqual(result['attributes'][1][1], expected['attributes'][1][1])
+
+        self.assertEqual(len(result['data']), len(expected['data']))
+        self.assertEqual(result['data'][0][0], expected['data'][0][0])
+        self.assertEqual(result['data'][0][1], expected['data'][0][1])
+        self.assertEqual(result['data'][0][2], expected['data'][0][2])
+        self.assertEqual(result['data'][0][3], expected['data'][0][3])
+        self.assertEqual(result['data'][0][4], expected['data'][0][4])
+
+    def test_decode_with_label_encoding(self):
+        decoder = self.get_decoder()
+
+        result = decoder.decode(ARFF, True)
+        expected = ENCODED_OBJ
 
         self.assertEqual(result['description'], expected['description'])
         self.assertEqual(result['relation'], expected['relation'])


### PR DESCRIPTION
The machine learning algorithms in the major python machine learning framework [scikit-learn](http://scikit-learn.org) cannot handle nominal values by themselve, but need a encoded labels ([see here](http://scikit-learn.org/stable/modules/preprocessing.html#label-encoding). Because this can be easily done at encoding time, and natively supports missing values, I added such functionality. If you consider this useful for others, please tell me and I will add documentation.