### PR TITLE
Small change to the _decode_data method to fix sparse data input

### DIFF
--- a/arff.py
+++ b/arff.py
@@ -438,14 +438,16 @@ class ArffDecoder(object):
         '''
         values = next(csv.reader([s.strip(' ')]))
 
+        # Sparse lines start with a '{' and are converted into dense lists. not listed values are set to zero
         if values[0][0].strip(" ") == '{':
             vdict = dict(map(lambda x: (int(x[0]), x[1]),[i.strip("{").strip("}").strip(" ").split(' ') for i in values]))
             values = [unicode(vdict[i]) if i in vdict else unicode(0) for i in xrange(len(self._conversors))]
+	# dense lines are decoded one by one
+        else:
+            if len(values) != len(self._conversors):
+                raise BadDataFormat()
+            values = [self._conversors[i](values[i]) for i in xrange(len(values))]
 
-        if len(values) != len(self._conversors):
-            raise BadDataFormat()
-
-        values = [self._conversors[i](values[i]) for i in xrange(len(values))]
         return values
 
     def _decode(self, s, encode_nominal=False):

--- a/arff.py
+++ b/arff.py
@@ -441,12 +441,12 @@ class ArffDecoder(object):
         # Sparse lines start with a '{' and are converted into dense lists. not listed values are set to zero
         if values[0][0].strip(" ") == '{':
             vdict = dict(map(lambda x: (int(x[0]), x[1]),[i.strip("{").strip("}").strip(" ").split(' ') for i in values]))
-            values = [unicode(vdict[i]) if i in vdict else unicode(0) for i in xrange(len(self._conversors))]
+            values = [vdict[i] if i in vdict else unicode(0) for i in xrange(len(self._conversors))]
 	# dense lines are decoded one by one
         else:
             if len(values) != len(self._conversors):
                 raise BadDataFormat()
-            values = [self._conversors[i](values[i]) for i in xrange(len(values))]
+        values = [self._conversors[i](values[i]) for i in xrange(len(values))]
 
         return values
 

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -28,6 +28,21 @@ ARFF_FORMAT_CORRECT = '''\
 @data 10,10,10
 '''
 
+SPARSE_ARFF = '''% XOR Dataset
+@RELATION XOR
+
+@ATTRIBUTE input1 REAL
+@ATTRIBUTE input2 REAL
+@ATTRIBUTE y REAL
+
+@DATA
+{0 0}
+{1 1.0, 2 1.0}
+{0 1.0, 2 1.0}
+{0 1.0, 1 1.0}
+'''
+
+
 class TestLoads(unittest.TestCase):
     def get_loads(self):
         load = arff.loads
@@ -89,3 +104,8 @@ class TestLoads(unittest.TestCase):
         with self.assertRaisesRegexp(arff.BadAttributeFormat, "Bad @ATTRIBUTE format, at line 3\.$"):
           obj = loads(ARFF_FORMAT_ERROR_ATTRIBUTE)
 
+    def test_sparse_input(self):
+        loads = self.get_loads()
+        obj = loads(ARFF)
+        sparse_obj = loads(SPARSE_ARFF)
+        self.assertEqual(obj['data'], sparse_obj['data'])


### PR DESCRIPTION
I just added an else to the _decode_data method. This fixes the problem that a BadData exception is thrown for sparse data because the number of values in each line is usually not the number of conversors.