### PR TITLE
Improve NaN handling and add documentation to complete pull request #20

### DIFF
--- a/arff.py
+++ b/arff.py
@@ -145,7 +145,6 @@ __version__ = '2.0.2'
 
 import re
 import csv
-import sys
 
 # CONSTANTS ===================================================================
 _SIMPLE_TYPES = ['NUMERIC', 'REAL', 'INTEGER', 'STRING']
@@ -259,15 +258,20 @@ class Conversor(object):
 
         if type_ == 'NUMERIC' or type_ == 'REAL':
             self._conversor = self._float
+            self._none = float('NaN')
         elif type_ == 'STRING':
             self._conversor = self._string
+            self._none = None
         elif type_ == 'INTEGER':
             self._conversor = self._integer
+            self._none = float('NaN')
         elif type_ == 'NOMINAL':
             self._conversor = self._nominal
+            self._none = None
         elif type_ == 'ENCODED_NOMINAL':
             self._conversor = self._encoded_nominal
             self._encoded_values = {value: i for i, value in enumerate(values)}
+            self._none = float('NaN')
         else:
             raise BadAttributeType()
 
@@ -313,7 +317,7 @@ class Conversor(object):
         value = value.strip(' ').strip('\"\'')
 
         if value == u'?' or value == u'':
-            return None
+            return self._none
 
         return self._conversor(value)
 # =============================================================================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -231,3 +231,91 @@ resulting in::
                [u'rainy', 71.0, 91.0, u'TRUE', u'no']],
      u'description': u'',
      u'relation': u'weather'}
+
+
+Loading An Object with encoded labels
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In some cases it is practical to have categorical data represented by
+integers, rather than strings. In `scikit-learn <http://scikit-learn.org>`_ for
+example, integer data can be directly converted in a continuous
+representation with the `One-Hot Encoder
+<http://scikit-learn.org/stable/modules/preprocessing.html#encoding-categorical-features>`_,
+which is necessary for most machine learning algorithms, e.g.
+`Support Vector Machines <http://en.wikipedia.org/wiki/Support_vector_machine>`_.
+The values ``[u'sunny', u'overcast', u'rainy']`` of the attribute
+``u'outlook'`` would be represented by ``[0, 1, 2]``. This representation can
+be directly used the  `One-Hot Encoder
+<http://scikit-learn.org/stable/modules/preprocessing.html#encoding-categorical-features>`_.
+
+Encoding categorical data while reading it from a file saves at least one
+memory copy and can be invoked like in this example::
+
+    import arff
+    import pprint
+
+    file_ = '''@RELATION weather
+
+    @ATTRIBUTE outlook {sunny, overcast, rainy}
+    @ATTRIBUTE temperature REAL
+    @ATTRIBUTE humidity REAL
+    @ATTRIBUTE windy {TRUE, FALSE}
+    @ATTRIBUTE play {yes, no}
+
+    @DATA
+    sunny,85.0,85.0,FALSE,no
+    sunny,80.0,90.0,TRUE,no
+    overcast,83.0,86.0,FALSE,yes
+    rainy,70.0,96.0,FALSE,yes
+    rainy,68.0,80.0,FALSE,yes
+    rainy,65.0,70.0,TRUE,no
+    overcast,64.0,65.0,TRUE,yes
+    sunny,72.0,95.0,FALSE,no
+    sunny,69.0,70.0,FALSE,yes
+    rainy,75.0,80.0,FALSE,yes
+    sunny,75.0,70.0,TRUE,yes
+    overcast,72.0,90.0,TRUE,yes
+    overcast,81.0,75.0,FALSE,yes
+    rainy,71.0,91.0,TRUE,no
+    %
+    %
+    % '''
+    decoder = arff.ArffDecoder()
+    d = decoder.decode(file_, encode_nominal=True)
+    pprint.pprint(d)
+
+resulting in::
+
+    {u'attributes': [(u'outlook', [u'sunny', u'overcast', u'rainy']),
+                 (u'temperature', u'REAL'),
+                 (u'humidity', u'REAL'),
+                 (u'windy', [u'TRUE', u'FALSE']),
+                 (u'play', [u'yes', u'no'])],
+     u'data': [[0, 85.0, 85.0, 1, 1],
+               [0, 80.0, 90.0, 0, 1],
+               [1, 83.0, 86.0, 1, 0],
+               [2, 70.0, 96.0, 1, 0],
+               [2, 68.0, 80.0, 1, 0],
+               [2, 65.0, 70.0, 0, 1],
+               [1, 64.0, 65.0, 0, 0],
+               [0, 72.0, 95.0, 1, 1],
+               [0, 69.0, 70.0, 1, 0],
+               [2, 75.0, 80.0, 1, 0],
+               [0, 75.0, 70.0, 0, 0],
+               [1, 72.0, 90.0, 0, 0],
+               [1, 81.0, 75.0, 1, 0],
+               [2, 71.0, 91.0, 0, 1]],
+     u'description': u'',
+     u'relation': u'weather'}
+
+
+Using this dataset in `scikit-learn <scikit-learn.org>`_::
+
+    from sklearn import preprocessing, svm
+    enc = preprocessing.OneHotEncoder(categorical_features=[0, 3, 4])
+    enc.fit(d['data'])
+    encoded_data = enc.transform(d['data']).toarray()
+    clf = svm.SVC()
+    clf.fit(encoded_data[:,0:4], encoded_data[:,4])
+
+

--- a/tests/test_conversor.py
+++ b/tests/test_conversor.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 import arff
 
@@ -116,21 +117,19 @@ class TestDecodeConversor(unittest.TestCase):
 
         conversor = self.get_conversor('ENCODED_NOMINAL', [u'a', u'b', u'3.4'])
         result = conversor('?')
-        expected = None
-        self.assertEqual(result, expected)
+        self.assertTrue(math.isnan(result))
 
         result = conversor('')
-        expected = None
-        self.assertEqual(result, expected)
+        self.assertTrue(math.isnan(result))
 
-        conversor = self.get_conversor('INTEGER')
-        result = conversor('?')
-        expected = None
-        self.assertEqual(result, expected)
+        numerical_types = ['INTEGER', 'REAL', 'NUMERIC']
+        for numerical_type in numerical_types:
+            conversor = self.get_conversor(numerical_type)
+            result = conversor('?')
+            self.assertTrue(math.isnan(result))
 
-        result = conversor('')
-        expected = None
-        self.assertEqual(result, expected)
+            result = conversor('')
+            self.assertTrue(math.isnan(result))
 
     def test_padding_value(self):
         '''Values such "    3.1415   "'''


### PR DESCRIPTION
Commit c112c7c adds better handling of missing values. For the attribute type *FLOAT*, *INTEGER*, *NUMERICAL*, missing values are replaced by `math.float('NaN')`

Commit efc2ce0 documents how to use `encode_labels` which I added with commit pull request #20.