### PR TITLE
Fix a typo in doc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -96,7 +96,7 @@ specifying its codification::
     import codecs
     import arff
 
-    file_ = codecs.load('/path/to/file.arff', 'rb', 'utf-8')
+    file_ = codecs.open('/path/to/file.arff', 'rb', 'utf-8')
     arff.load(file_)
 
 


### PR DESCRIPTION
I found a typo in documentation regarding usage of Python's codecs module.
Can you check the diff and merge the pull request if it's appropriate?

Thank you.
