### PR TITLE
Fix for Issue #6

### DIFF
--- a/arff.py
+++ b/arff.py
@@ -602,7 +602,7 @@ class ArffDecoder(object):
         # Extracts the final type
         if _RE_TYPE_NOMINAL.match(type_):
             # If follows the nominal structure, parse with csv reader.
-            values = next(csv.reader([type_.strip('{} ')]))
+            values = next(csv.reader([type_.strip('{} ')],quotechar="'",escapechar="\\"))
             values = [unicode(v_.strip(' ').strip('"\'')) for v_ in values]
             type_ = values
 

--- a/arff.py
+++ b/arff.py
@@ -28,34 +28,34 @@
 '''
 The liac-arff module implements functions to read and write ARFF files in
 Python. It was created in the Connectionist Artificial Intelligence Laboratory
-(LIAC), which takes place at the Federal University of Rio Grande do Sul 
+(LIAC), which takes place at the Federal University of Rio Grande do Sul
 (UFRGS), in Brazil.
 
 ARFF (Attribute-Relation File Format) is an file format specially created for
 describe datasets which are commonly used for machine learning experiments and
-softwares. This file format was created to be used in Weka, the best 
+softwares. This file format was created to be used in Weka, the best
 representative software for machine learning automated experiments.
 
-An ARFF file can be divided into two sections: header and data. The Header 
-describes the metadata of the dataset, including a general description of the 
-dataset, its name and its attributes. The source below is an example of a 
+An ARFF file can be divided into two sections: header and data. The Header
+describes the metadata of the dataset, including a general description of the
+dataset, its name and its attributes. The source below is an example of a
 header section in a XOR dataset::
 
-    % 
+    %
     % XOR Dataset
-    % 
+    %
     % Created by Renato Pereira
     %            rppereira@inf.ufrgs.br
     %            http://inf.ufrgs.br/~rppereira
-    % 
-    % 
+    %
+    %
     @RELATION XOR
 
     @ATTRIBUTE input1 REAL
     @ATTRIBUTE input2 REAL
     @ATTRIBUTE y REAL
 
-The Data section of an ARFF file describes the observations of the dataset, in 
+The Data section of an ARFF file describes the observations of the dataset, in
 the case of XOR dataset::
 
     @DATA
@@ -63,13 +63,13 @@ the case of XOR dataset::
     0.0,1.0,1.0
     1.0,0.0,1.0
     1.0,1.0,0.0
-    % 
-    % 
-    % 
+    %
+    %
+    %
 
-Notice that several lines are starting with an ``%`` symbol, denoting a 
+Notice that several lines are starting with an ``%`` symbol, denoting a
 comment, thus, lines with ``%`` at the beginning will be ignored, except by the
-description part at the beginning of the file. The declarations ``@RELATION``, 
+description part at the beginning of the file. The declarations ``@RELATION``,
 ``@ATTRIBUTE``, and ``@DATA`` are all case insensitive and obligatory.
 
 For more information and details about the ARFF file description, consult
@@ -79,29 +79,29 @@ http://www.cs.waikato.ac.nz/~ml/weka/arff.html
 ARFF Files in Python
 ~~~~~~~~~~~~~~~~~~~~
 
-This module uses built-ins python objects to represent a deserialized ARFF 
+This module uses built-ins python objects to represent a deserialized ARFF
 file. A dictionary is used as the container of the data and metadata of ARFF,
 and have the following keys:
 
 - **description**: (OPTIONAL) a string with the description of the dataset.
 - **relation**: (OBLIGATORY) a string with the name of the dataset.
-- **attributes**: (OBLIGATORY) a list of attributes with the following 
+- **attributes**: (OBLIGATORY) a list of attributes with the following
   template::
 
     (attribute_name, attribute_type)
 
   the attribute_name is a string, and attribute_type must be an string
   or a list of strings.
-- **data**: (OBLIGATORY) a list of data instances. Each data instance must be 
+- **data**: (OBLIGATORY) a list of data instances. Each data instance must be
   a list with values, depending on the attributes.
 
-The above keys must follow the case which were described, i.e., the keys are 
-case sensitive. The attribute type ``attribute_type`` must be one of these 
-strings (they are not case sensitive): ``NUMERIC``, ``INTEGER``, ``REAL`` or 
-``STRING``. For nominal attributes, the ``atribute_type`` must be a list of 
+The above keys must follow the case which were described, i.e., the keys are
+case sensitive. The attribute type ``attribute_type`` must be one of these
+strings (they are not case sensitive): ``NUMERIC``, ``INTEGER``, ``REAL`` or
+``STRING``. For nominal attributes, the ``atribute_type`` must be a list of
 strings.
 
-In this format, the XOR dataset presented above can be represented as a python 
+In this format, the XOR dataset presented above can be represented as a python
 object as::
 
     xor_dataset = {
@@ -133,7 +133,7 @@ This module provides several features, including:
   and lists of dictionaries as used by SVMLight
 - Supports the following attribute types: NUMERIC, REAL, INTEGER, STRING, and
   NOMINAL;
-- Has an interface similar to other built-in modules such as ``json``, or 
+- Has an interface similar to other built-in modules such as ``json``, or
   ``zipfile``;
 - Supports read and write the descriptions of files;
 - Supports missing values and names with spaces;
@@ -219,17 +219,17 @@ class BadDataFormat(ArffException):
     message = 'Bad @DATA instance format, at line %d.'
 
 class BadAttributeType(ArffException):
-    '''Error raised when some invalid type is provided into the attribute 
+    '''Error raised when some invalid type is provided into the attribute
     declaration.'''
     message = 'Bad @ATTRIBUTE type, at line %d.'
 
 class BadNominalValue(ArffException):
-    '''Error raised when a value in used in some data instance but is not 
+    '''Error raised when a value in used in some data instance but is not
     declared into it respective attribute declaration.'''
     message = 'Data value not found in nominal declaration, at line %d.'
 
 class BadNumericalValue(ArffException):
-    '''Error raised when and invalid numerical value is used in some data 
+    '''Error raised when and invalid numerical value is used in some data
     instance.'''
     message = 'Invalid numerical value, at line %d.'
 
@@ -238,14 +238,14 @@ class BadLayout(ArffException):
     message = 'Invalid layout of the ARFF file, at line %d.'
 
 class BadObject(ArffException):
-    '''Error raised when the object representing the ARFF file has something 
+    '''Error raised when the object representing the ARFF file has something
     wrong.'''
 
     def __str__(self):
         return 'Invalid object.'
 
 class BadObject(ArffException):
-    '''Error raised when the object representing the ARFF file has something 
+    '''Error raised when the object representing the ARFF file has something
     wrong.'''
     def __init__(self, msg=''):
         self.msg = msg
@@ -316,7 +316,7 @@ class Conversor(object):
         return self._encoded_values[value]
 
     def __call__(self, value):
-        '''Convert a ``value`` to a given type. 
+        '''Convert a ``value`` to a given type.
 
         This function also verify if the value is an empty string or a missing
         value, either cases, it returns None.
@@ -335,7 +335,7 @@ class Data(object):
         self.data = []
 
     def decode_data(self, s, conversors):
-        values = next(csv.reader([s.strip(' ')]))
+        values = next(csv.reader([row.strip(' ')],quotechar="'",escapechar="\\"))
 
         if values[0][0].strip(" ") == '{':
             vdict = dict(map(lambda x: (int(x[0]), x[1]),
@@ -524,7 +524,7 @@ class ArffDecoder(object):
         characters.
 
         This method must receive a normalized string, i.e., a string without
-        padding, including the "\r\n" characters. 
+        padding, including the "\r\n" characters.
 
         :param s: a normalized string.
         :return: a string with the decoded comment.
@@ -535,13 +535,13 @@ class ArffDecoder(object):
     def _decode_relation(self, s):
         '''(INTERNAL) Decodes a relation line.
 
-        The relation declaration is a line with the format ``@RELATION 
+        The relation declaration is a line with the format ``@RELATION
         <relation-name>``, where ``relation-name`` is a string. The string must
         start with alphabetic character and must be quoted if the name includes
         spaces, otherwise this method will raise a `BadRelationFormat` exception.
 
         This method must receive a normalized string, i.e., a string without
-        padding, including the "\r\n" characters. 
+        padding, including the "\r\n" characters.
 
         :param s: a normalized string.
         :return: a string with the decoded relation name.
@@ -558,12 +558,12 @@ class ArffDecoder(object):
     def _decode_attribute(self, s):
         '''(INTERNAL) Decodes an attribute line.
 
-        The attribute is the most complex declaration in an arff file. All 
+        The attribute is the most complex declaration in an arff file. All
         attributes must follow the template::
 
              @attribute <attribute-name> <datatype>
 
-        where ``attribute-name`` is a string, quoted if the name contains any 
+        where ``attribute-name`` is a string, quoted if the name contains any
         whitespace, and ``datatype`` can be:
 
         - Numerical attributes as ``NUMERIC``, ``INTEGER`` or ``REAL``.
@@ -571,13 +571,13 @@ class ArffDecoder(object):
         - Dates (NOT IMPLEMENTED).
         - Nominal attributes with format:
 
-            {<nominal-name1>, <nominal-name2>, <nominal-name3>, ...} 
+            {<nominal-name1>, <nominal-name2>, <nominal-name3>, ...}
 
         The nominal names follow the rules for the attribute names, i.e., they
         must be quoted if the name contains whitespaces.
 
         This method must receive a normalized string, i.e., a string without
-        padding, including the "\r\n" characters. 
+        padding, including the "\r\n" characters.
 
         :param s: a normalized string.
         :return: a tuple (ATTRIBUTE_NAME, TYPE_OR_VALUES).
@@ -750,8 +750,8 @@ class ArffEncoder(object):
     def _encode_relation(self, name):
         '''(INTERNAL) Decodes a relation line.
 
-        The relation declaration is a line with the format ``@RELATION 
-        <relation-name>``, where ``relation-name`` is a string. 
+        The relation declaration is a line with the format ``@RELATION
+        <relation-name>``, where ``relation-name`` is a string.
 
         :param name: a string.
         :return: a string with the encoded relation declaration.
@@ -777,7 +777,7 @@ class ArffEncoder(object):
         - Dates (NOT IMPLEMENTED).
         - Nominal attributes with format:
 
-            {<nominal-name1>, <nominal-name2>, <nominal-name3>, ...} 
+            {<nominal-name1>, <nominal-name2>, <nominal-name3>, ...}
 
         This method must receive a the name of the attribute and its type, if
         the attribute type is nominal, ``type`` must be a list of values.
@@ -810,7 +810,7 @@ class ArffEncoder(object):
     def iter_encode(self, obj):
         '''The iterative version of `arff.ArffEncoder.encode`.
 
-        This encodes iteratively a given object and return, one-by-one, the 
+        This encodes iteratively a given object and return, one-by-one, the
         lines of the ARFF file.
 
         :param obj: the object containing the ARFF information.
@@ -831,7 +831,7 @@ class ArffEncoder(object):
         # ATTRIBUTES
         if not obj.get('attributes'):
             raise BadObject('Attributes not found.')
-            
+
         for attr in obj['attributes']:
             # Verify for bad object format
             if not isinstance(attr, (tuple, list)) or \
@@ -868,7 +868,7 @@ class ArffEncoder(object):
 # BASIC INTERFACE =============================================================
 def load(fp, encode_nominal=False, return_type=DENSE):
     '''Load a file-like object containing the ARFF document and convert it into
-    a Python object. 
+    a Python object.
 
     :param fp: a file-like object.
     :param encode_nominal: boolean, if True perform a label encoding
@@ -899,7 +899,7 @@ def loads(s, encode_nominal=False, return_type=DENSE):
                           return_type=return_type)
 
 def dump(obj, fp):
-    '''Serialize an object representing the ARFF document to a given file-like 
+    '''Serialize an object representing the ARFF document to a given file-like
     object.
 
     :param obj: a dictionary.

--- a/arff.py
+++ b/arff.py
@@ -337,6 +337,7 @@ class Data(object):
     def decode_data(self, s, conversors):
         values = next(csv.reader([s.strip(' ')],quotechar="'",escapechar="\\"))
 
+
         if values[0][0].strip(" ") == '{':
             vdict = dict(map(lambda x: (int(x[0]), x[1]),
                              [i.strip("{").strip("}").strip(" ").split(' ') for
@@ -385,7 +386,8 @@ class COOData(Data):
         self._current_num_data_points = 0
 
     def decode_data(self, s, conversors):
-        values = next(csv.reader([s.strip(' ')]))
+        values = next(csv.reader([s.strip(' ')],quotechar="'",escapechar="\\"))
+
 
         if not values[0][0].strip(" ") == '{':
             raise BadLayout()
@@ -448,7 +450,8 @@ class LODData(Data):
         self.data = []
 
     def decode_data(self, s, conversors):
-        values = next(csv.reader([s.strip(' ')]))
+        values = next(csv.reader([s.strip(' ')],quotechar="'",escapechar="\\"))
+
 
         if not values[0][0].strip(" ") == '{':
             raise BadLayout()

--- a/arff.py
+++ b/arff.py
@@ -335,7 +335,7 @@ class Data(object):
         self.data = []
 
     def decode_data(self, s, conversors):
-        values = next(csv.reader([row.strip(' ')],quotechar="'",escapechar="\\"))
+        values = next(csv.reader([s.strip(' ')],quotechar="'",escapechar="\\"))
 
         if values[0][0].strip(" ") == '{':
             vdict = dict(map(lambda x: (int(x[0]), x[1]),


### PR DESCRIPTION
This is a simple fix for issue #6: The ARFF spec does allow comma's in category names, but this is not parsed well by liac-arff. It is fixed by changing the call to the cvs reader on 3 locations.

Thanks!

PS. Sorry about the whitespace diff, I can't seem to get rid of that.
