### PR TITLE
adding DATE to data types; allow a formatting string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,7 @@ Contributors
 - `Matthias Feurer (mfeurer) <https://github.com/mfeurer>`_
 - `Hongjoo Lee (midnightradio) <https://github.com/midnightradio>`_
 - `Calvin Jeong (calvin) <http://ty.pe.kr/>`_
+- `Todd Cook (todd-cook) <https://github.com/todd-cook>`_
 
 Project Page
 ------------

--- a/arff.py
+++ b/arff.py
@@ -625,9 +625,9 @@ class ArffDecoder(object):
         else:
             # If not nominal, verify the type name
             type_ = unicode(type_).upper()
-            if ' ' in type_:
+            if 'DATE' in type_ and ' ' in type_:
                 try:
-                    type_, format = type_.split(' ')
+                    type_, format = type_[:type_.find(' ')], type_[type_.find(' ') + 1:]
                     return (name, type_, format)
                 except ValueError:
                     raise BadAttributeType()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -425,3 +425,59 @@ constructor::
     row = d['data'][1]
     col = d['data'][2]
     matrix = sparse.coo_matrix((data, (row, col)), shape=(max(row)+1, max(col)+1))
+
+
+Working with Date objects
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Date data can be encoded into an arff file as an attribute and an optional format
+specification can be made.
+The recommended format is: ISO 8601 format, YYYY-MM-DDTHH:MM:SS.mmmmmm; however,
+any level of precision is acceptable. The format string must contain the proper
+percent sign escaped formatting characters, e.g.: '%Y/%m/%dT%H:%M:%S'. Because date
+values may contain a space, their data representations should be quoted.
+
+If no format specification is given, the date format will be guessed using the
+dateutil library; the closer the data is in the format of ISO 8601, the greater the
+chance of a successful conversion.
+Serializing an arff data structure will use the ISO 8601 formatting.
+
+Here is an example::
+
+   import arff
+   import pprint
+
+   file_ = '''@RELATION employee
+   @ATTRIBUTE Name STRING
+   @ATTRIBUTE start_date DATE
+   @ATTRIBUTE end_date DATE '%Y/%m/%dT%H:%M:%S'
+   @ATTRIBUTE simple_date DATE '%Y/%m/%d'
+   @DATA
+   Lulu,'2011-05-20T12:34:56','2014/06/21T12:34:56','2018/03/04'
+   Daisy,'2012-09-30T12:34:56','2015/11/21T12:34:56','2018/03/04'
+   Brie,'2013-05-01T12:34:56','2016/12/21T12:34:56','2018/03/04'
+   '''
+   decoder = arff.ArffDecoder()
+   d = decoder.decode(file_, encode_nominal=True)
+   pprint.pprint(d)
+
+resulting in::
+
+   {'attributes': [('Name', 'STRING'),
+                    ('start_date', 'DATE'),
+                    ('end_date', 'DATE', "'%Y/%m/%dT%H:%M:%S'"),
+                    ('simple_date', 'DATE', "'%Y/%m/%d'")],
+    'data': [['Lulu',
+               datetime.datetime(2011, 5, 20, 12, 34, 56),
+               datetime.datetime(2014, 6, 21, 12, 34, 56),
+               datetime.datetime(2018, 3, 4, 0, 0)],
+              ['Daisy',
+               datetime.datetime(2012, 9, 30, 12, 34, 56),
+               datetime.datetime(2015, 11, 21, 12, 34, 56),
+               datetime.datetime(2018, 3, 4, 0, 0)],
+              ['Brie',
+               datetime.datetime(2013, 5, 1, 12, 34, 56),
+               datetime.datetime(2016, 12, 21, 12, 34, 56),
+               datetime.datetime(2018, 3, 4, 0, 0)]],
+    'description': '',
+    'relation': 'employee'}

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,5 @@ setup(
     py_modules=['arff'],
     package_data={'':['README.rst', 'CHANGES.rst', 'LICENSE']},
     test_suite='tests',
+    install_requires = ['python-dateutil'],
 )

--- a/tests/test_decode_attribute.py
+++ b/tests/test_decode_attribute.py
@@ -51,6 +51,21 @@ class TestDecodeAttribute(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0], expected)
 
+    def test_date_name(self):
+        '''Attributes with quoted name but without space.'''
+        decoder = self.get_decoder()
+
+        # Double Quote
+        fixture = u'@ATTRIBUTE 0 DATE "Y-M-D"'
+        result = decoder._decode_attribute(fixture)
+        expected = u'0'
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0], expected)
+        name, type_, format = result
+        self.assertEqual(format, u'"Y-M-D"')
+
+
     def test_quoted_special(self):
         '''Attributes with quoted name but without space.'''
         decoder = self.get_decoder()

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -165,3 +165,20 @@ class TestLoads(unittest.TestCase):
         loads = self.get_loads()
         obj = loads(ARFF_WITH_DATE)
         self.assertEqual(obj['data'], [[datetime.datetime(2012, 7, 27, 0, 0)]])
+
+    def test_date_formatting_complex(self):
+        '''Test the date conversion using a supplied complex formatting string.'''
+        ARFF_WITH_DATE = '''% XOR Dataset
+@RELATION event_date
+
+@attribute occurs DATE "%m/%d/%Y HH:mm"
+
+@DATA
+"07/27/2012 12:34"
+%
+%
+% '''
+
+        loads = self.get_loads()
+        obj = loads(ARFF_WITH_DATE)
+        self.assertEqual(obj['data'], [[datetime.datetime(2012, 7, 27, 12, 34)]])

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -1,5 +1,6 @@
 import unittest
 import arff
+import datetime
 try:
     from StringIO import StringIO
 except ImportError:
@@ -127,3 +128,40 @@ class TestLoads(unittest.TestCase):
         loads = self.get_loads()
         obj = loads(ARFF_WITH_NULL)
         self.assertEqual(obj['data'], [['Y'], ['?'], ['Y'], ['?']])
+
+    def test_date(self):
+        '''Test the date conversion; by coercion.'''
+        ARFF_WITH_DATE = '''% XOR Dataset
+@RELATION event_date
+
+@attribute occurs DATE
+
+@DATA
+'2011-01-11'
+'2010-10-01'
+%
+%
+% '''
+
+        loads = self.get_loads()
+        obj = loads(ARFF_WITH_DATE)
+        self.assertEqual(obj['data'], [
+            [datetime.datetime(2011, 1, 11, 0, 0)], [datetime.datetime(2010, 10, 1, 0, 0)]])
+
+
+    def test_date_formatting(self):
+        '''Test the date conversion using a supplied formatting string.'''
+        ARFF_WITH_DATE = '''% XOR Dataset
+@RELATION event_date
+
+@attribute occurs DATE "%m/%d/%Y"
+
+@DATA
+"07/27/2012"
+%
+%
+% '''
+
+        loads = self.get_loads()
+        obj = loads(ARFF_WITH_DATE)
+        self.assertEqual(obj['data'], [[datetime.datetime(2012, 7, 27, 0, 0)]])

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -112,18 +112,18 @@ class TestLoads(unittest.TestCase):
 
     def test_quoted_null(self):
         ARFF_WITH_NULL = '''% XOR Dataset
-@RELATION XOR
-
-@attribute 'bc' {'?','Y'}
-
-@DATA
-'Y'
-'?'
-'Y'
-'?'
-%
-%
-% '''
+        @RELATION XOR
+        
+        @attribute 'bc' {'?','Y'}
+        
+        @DATA
+        'Y'
+        '?'
+        'Y'
+        '?'
+        %
+        %
+        % '''
 
         loads = self.get_loads()
         obj = loads(ARFF_WITH_NULL)
@@ -132,16 +132,16 @@ class TestLoads(unittest.TestCase):
     def test_date(self):
         '''Test the date conversion; by coercion.'''
         ARFF_WITH_DATE = '''% XOR Dataset
-@RELATION event_date
-
-@attribute occurs DATE
-
-@DATA
-'2011-01-11'
-'2010-10-01'
-%
-%
-% '''
+        @RELATION event_date
+        
+        @attribute occurs DATE
+        
+        @DATA
+        '2011-01-11'
+        '2010-10-01'
+        %
+        %
+        % '''
 
         loads = self.get_loads()
         obj = loads(ARFF_WITH_DATE)
@@ -152,15 +152,15 @@ class TestLoads(unittest.TestCase):
     def test_date_formatting(self):
         '''Test the date conversion using a supplied formatting string.'''
         ARFF_WITH_DATE = '''% XOR Dataset
-@RELATION event_date
-
-@attribute occurs DATE "%m/%d/%Y"
-
-@DATA
-"07/27/2012"
-%
-%
-% '''
+        @RELATION event_date
+        
+        @attribute occurs DATE "%m/%d/%Y"
+        
+        @DATA
+        "07/27/2012"
+        %
+        %
+        % '''
 
         loads = self.get_loads()
         obj = loads(ARFF_WITH_DATE)
@@ -169,15 +169,15 @@ class TestLoads(unittest.TestCase):
     def test_date_formatting_complex(self):
         '''Test the date conversion using a supplied complex formatting string.'''
         ARFF_WITH_DATE = '''% XOR Dataset
-@RELATION event_date
-
-@attribute occurs DATE "%m/%d/%Y HH:mm"
-
-@DATA
-"07/27/2012 12:34"
-%
-%
-% '''
+        @RELATION event_date
+        
+        @attribute occurs DATE "%m/%d/%Y %H:%m"
+        
+        @DATA
+        "07/27/2012 12:34"
+        %
+        %
+        % '''
 
         loads = self.get_loads()
         obj = loads(ARFF_WITH_DATE)

--- a/tests/test_loads_dumps.py
+++ b/tests/test_loads_dumps.py
@@ -62,3 +62,25 @@ class TestLoadDump(unittest.TestCase):
             arff = dumps(obj)
             self.assertEqual(arff, ARFF)
 
+    def test_date(self):
+        file_ = '''@RELATION employee
+        @ATTRIBUTE Name STRING
+        @ATTRIBUTE start_date DATE
+        @ATTRIBUTE end_date DATE '%Y/%m/%dT%H:%M:%S'
+        @ATTRIBUTE simple_date DATE '%Y/%m/%d'        
+        @DATA
+        Lulu,'2011-05-20T12:34:56','2014/06/21T12:34:56','2018/03/04'
+        Daisy,'2012-09-30T12:34:56','2015/11/21T12:34:56','2018/03/04'
+        Brie,'2013-05-01T12:34:56','2016/12/21T12:34:56','2018/03/04'
+        '''
+        decoder = arff.ArffDecoder()
+        d = decoder.decode(file_, encode_nominal=True)
+        reconstituted = arff.dumps(d)
+        decoder2 = arff.ArffDecoder()
+        d2 = decoder2.decode(reconstituted, encode_nominal=True)
+        self.assertEqual(d['data'][1][1] , d2['data'][1][1])
+        self.assertEqual(d['data'][1][2] , d2['data'][1][2])
+        self.assertEqual(d['data'][1][3] , d2['data'][1][3])
+        self.assertEqual(d['data'][2][1], d2['data'][2][1])
+        self.assertEqual(d['data'][2][2], d2['data'][2][2])
+        self.assertEqual(d['data'][2][3], d2['data'][2][3])


### PR DESCRIPTION
use dateutil.parser.parse for smart parsing/best guess, but
allow users to specify a string format and use
datetime.strptime(value, self._date_format) for specifying a format.
see also: 
https://github.com/renatopp/liac-arff/issues/44