### PR TITLE
test_conversors now tests end-to-end decoding

### DIFF
--- a/arff.py
+++ b/arff.py
@@ -282,7 +282,7 @@ class BadLayout(ArffException):
     def __init__(self, msg=''):
         super(BadLayout, self).__init__()
         if msg:
-            self.message = BadLayout.message + ' ' + msg
+            self.message = BadLayout.message + ' ' + msg.replace('%', '%%')
 
 class BadObject(ArffException):
     '''Error raised when the object representing the ARFF file has something 

--- a/arff.py
+++ b/arff.py
@@ -196,8 +196,9 @@ def _build_re_sparse():
                       \s+
                       (%(value_re)s) # value
                       |
-                      (?!}\s*$)
-                      \S.*            # error
+                      (?!}\s*$)      # not an error if it's }$
+                      (?!^\s*{\s*}\s*$)  # not an error if it's ^{}$
+                      \S.*           # error
                       '''
                       % {'value_re': value_re})
 

--- a/arff.py
+++ b/arff.py
@@ -173,10 +173,11 @@ def _build_re_sparse():
     quoted_re = r'''(?x)
                     "      # open quote followed by zero or more of:
                     (?:
-                        (?<!\\)
-                        \\"       # escaped quote (if backslash is not escaped)
+                        (?<!\\)    # no additional backslash
+                        (?:\\\\)*  # maybe escaped backslashes
+                        \\"        # escaped quote
                     |
-                        [^"]      # non-quote char
+                        [^"]       # non-quote char
                     )*
                     "      # close quote
                     '''

--- a/arff.py
+++ b/arff.py
@@ -368,7 +368,15 @@ class Data(object):
     def _get_values(self, s):
         '''(INTERNAL) Split a line into a list of values'''
         if _RE_QUOTATION_MARKS.search(s):
-            return _read_csv(s.strip(' '))
+            if s.rstrip().endswith('}'):
+                # TODO: pull this out / neaten up sparse handling
+                quoted_re = r'"(?:(?<!\\)\\"|[^"])+"'
+                value_re = r'(?:%s|%s|[^,\s]+)' % (quoted_re,
+                                                   quoted_re.replace('"', "'"))
+                return re.findall(r'''(?:^\s*\{|,)\s*\d+\s+%(value_re)s'''
+                                  % {'value_re': value_re}, s)
+            else:
+                return _read_csv(s.strip(' '))
         else:
             return next(csv.reader([s.strip(' ')]))
 

--- a/tests/test_conversor.py
+++ b/tests/test_conversor.py
@@ -137,27 +137,32 @@ class BaseTestDecodeConversor(object):
         expected = None
         self.assertEqual(result, expected)
 
-        result = conversor('')
-        expected = None
-        self.assertEqual(result, expected)
+        if not self.use_sparse:
+            # using an empty string as missing value in sparse ARFF syntax is
+            # awkward and presumably forbidden
+            result = conversor('')
+            expected = None
+            self.assertEqual(result, expected)
 
         conversor = self.get_conversor('ENCODED_NOMINAL', [u'a', u'b', u'3.4'])
         result = conversor('?')
         expected = None
         self.assertEqual(result, expected)
 
-        result = conversor('')
-        expected = None
-        self.assertEqual(result, expected)
+        if not self.use_sparse:
+            result = conversor('')
+            expected = None
+            self.assertEqual(result, expected)
 
         conversor = self.get_conversor('INTEGER')
         result = conversor('?')
         expected = None
         self.assertEqual(result, expected)
 
-        result = conversor('')
-        expected = None
-        self.assertEqual(result, expected)
+        if not self.use_sparse:
+            result = conversor('')
+            expected = None
+            self.assertEqual(result, expected)
 
     def test_padding_value(self):
         '''Values such "    3.1415   "'''

--- a/tests/test_conversor.py
+++ b/tests/test_conversor.py
@@ -237,3 +237,18 @@ class TestDecodeConversorCOO(BaseTestDecodeConversor, unittest.TestCase):
             assert col == [0]
             return data[0]
         return conversor
+
+
+class TestDecodeConversorLOD(BaseTestDecodeConversor, unittest.TestCase):
+    use_sparse = True
+
+    def get_conversor(self, type_, values=None):
+        load = self._get_arff_loader(arff.LOD, type_, values)
+
+        def conversor(value):
+            data = load(value)['data']
+            assert len(data) == 1
+            assert isinstance(data[0], dict)
+            assert len(data[0]) == 1
+            return data[0][0]
+        return conversor

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -361,18 +361,16 @@ class TestInvalidValues(unittest.TestCase):
     def test_sparse(self):
 
         fixture = self.my_arff.format(data="{0 a',1 'c d'}")
-        with self.assertRaisesRegexp(ValueError,
-                                     "Expected comma or whitespace at position"
-                                     " 9, not c for line {0 a',1 'c d'}."):
+        with self.assertRaisesRegexp(arff.ArffException,
+                                     ".*',1 'c d'}."):
             arff.load(fixture)
 
         fixture = self.my_arff.format(data="{0 a b,1 'c d'}")
-        with self.assertRaisesRegexp(arff.BadStringValue,
-                                     "Invalid string value at line 8."):
+        with self.assertRaisesRegexp(arff.ArffException,
+                                     ".*b,1 'c d'"):
             print(arff.load(fixture))
 
         fixture = self.my_arff.format(data="{0 'a b', 1 c d}")
-        with self.assertRaisesRegexp(arff.BadNominalFormatting,
-                                     'Nominal data value "c d" not properly '
-                                     'quoted in line 8'):
+        with self.assertRaisesRegexp(arff.ArffException,
+                                     r'.*d\}'):
             print(arff.load(fixture))


### PR DESCRIPTION
Nowhere properly tested decoding values in a sparse context. Focused unit testing of Conversor was the wrong way to go about testing this function, and it allowed us to think end-to-end functionality was working when it wasn't.

As such these tests fail, and I will endeavor to fix the implementations.

So I expect this will:

* fix #77 
* be helpful in completing #76