### PR TITLE
MNT Avoid deprecation warnings in Python >= 3.6

### DIFF
--- a/arff.py
+++ b/arff.py
@@ -171,7 +171,7 @@ _RE_NONTRIVIAL_DATA = re.compile('["\'{}\\s]')
 
 
 def _build_re_values():
-    quoted_re = r'''(?x)
+    quoted_re = r'''
                     "      # open quote followed by zero or more of:
                     (?:
                         (?<!\\)    # no additional backslash
@@ -185,7 +185,7 @@ def _build_re_values():
                     "      # close quote
                     '''
     # a value is surrounded by " or by ' or contains no quotables
-    value_re = r'''(?x)(?:
+    value_re = r'''(?:
         %s|          # a value may be surrounded by "
         %s|          # or by '
         [^,\s"'{}]+  # or may contain no characters requiring quoting


### PR DESCRIPTION
@jorisvandenbossche claims import results in the following warning in Python 3.6:

```
sklearn/externals/_arff.py:204: DeprecationWarning: Flags not at the start of the expression '(?x)\n        ,      ' (truncated)
  ''' % {'value_re': value_re})
```

I can't see it in the travis logs here, but this PR should fix that.

It looks like there may be other deprecation warnings firing in tests. They should be looked into.