### PR TITLE
fix for escape sequence issue in python 3.7

### DIFF
--- a/arff.py
+++ b/arff.py
@@ -641,7 +641,7 @@ class ArffDecoder(object):
         :param s: a normalized string.
         :return: a string with the decoded comment.
         '''
-        res = re.sub('^\%( )?', '', s)
+        res = re.sub(r'^\%( )?', '', s)
         return res
 
     def _decode_relation(self, s):


### PR DESCRIPTION
Python3.7 escape sequence issue fix.

Fixed in `scikit-learn` in https://github.com/scikit-learn/scikit-learn/pull/12064

Python3.7 raises an exception with a message like "invalid escape sequence \%".