### PR TITLE
FIX: match all possible space separator to add quotes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ What's New on LIAC-ARFF
 
 LIAC-ARFF 2.3.2
 * fix: match all possible separator spaces to add quotes to be compliant with
-  ARFF format.
+  ARFF format when writing.
 
 LIAC-ARFF 2.3.1
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 What's New on LIAC-ARFF
 =======================
 
+LIAC-ARFF 2.3.2
+* fix: match all possible separator spaces to add quotes to be compliant with
+  ARFF format.
+
 LIAC-ARFF 2.3.1
 
 * maintenance: replace two bare ``raise`` by appropriate ``raise Exception``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,6 @@ LIAC-ARFF 2.3.2
 * fix: match all possible separator spaces to add quotes when encoding into
   ARFF. These separator spaces will be preserved when decoding the ARFF files.
 
-match all possible separator spaces to add quotes to be compliant with
-  ARFF format when writing.
-
 LIAC-ARFF 2.3.1
 
 * maintenance: replace two bare ``raise`` by appropriate ``raise Exception``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,10 @@ What's New on LIAC-ARFF
 =======================
 
 LIAC-ARFF 2.3.2
-* fix: match all possible separator spaces to add quotes to be compliant with
+* fix: match all possible separator spaces to add quotes when encoding into
+  ARFF. These separator spaces will be preserved when decoding the ARFF files.
+
+match all possible separator spaces to add quotes to be compliant with
   ARFF format when writing.
 
 LIAC-ARFF 2.3.1

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,7 @@ Contributors
 - `Hongjoo Lee (midnightradio) <https://github.com/midnightradio>`_
 - `Calvin Jeong (calvin) <http://ty.pe.kr/>`_
 - `Joel Nothman (jnothman) <https://github.com/jnothman>`_
+- `Guillaume Lemaitre (glemaitre) <https://github.com/glemaitre>`_
 
 Project Page
 ------------

--- a/arff.py
+++ b/arff.py
@@ -164,7 +164,7 @@ _TK_DATA        = '@DATA'
 _RE_RELATION     = re.compile(r'^([^\{\}%,\s]*|\".*\"|\'.*\')$', re.UNICODE)
 _RE_ATTRIBUTE    = re.compile(r'^(\".*\"|\'.*\'|[^\{\}%,\s]*)\s+(.+)$', re.UNICODE)
 _RE_TYPE_NOMINAL = re.compile(r'^\{\s*((\".*\"|\'.*\'|\S*)\s*,\s*)*(\".*\"|\'.*\'|\S*)\s*\}$', re.UNICODE)
-_RE_QUOTE_CHARS = re.compile(r'["\'\\ \t%,]')
+_RE_QUOTE_CHARS = re.compile(r'["\'\s%,]')
 _RE_ESCAPE_CHARS = re.compile(r'(?=["\'\\%])')  # don't need to capture anything
 _RE_SPARSE_LINE = re.compile(r'^\{.*\}$')
 _RE_NONTRIVIAL_DATA = re.compile('["\'{}\\s]')

--- a/arff.py
+++ b/arff.py
@@ -164,7 +164,7 @@ _TK_DATA        = '@DATA'
 _RE_RELATION     = re.compile(r'^([^\{\}%,\s]*|\".*\"|\'.*\')$', re.UNICODE)
 _RE_ATTRIBUTE    = re.compile(r'^(\".*\"|\'.*\'|[^\{\}%,\s]*)\s+(.+)$', re.UNICODE)
 _RE_TYPE_NOMINAL = re.compile(r'^\{\s*((\".*\"|\'.*\'|\S*)\s*,\s*)*(\".*\"|\'.*\'|\S*)\s*\}$', re.UNICODE)
-_RE_QUOTE_CHARS = re.compile(r'["\'\s%,]')
+_RE_QUOTE_CHARS = re.compile(r'["\'\s%,]', re.UNICODE)
 _RE_ESCAPE_CHARS = re.compile(r'(?=["\'\\%])')  # don't need to capture anything
 _RE_SPARSE_LINE = re.compile(r'^\{.*\}$')
 _RE_NONTRIVIAL_DATA = re.compile('["\'{}\\s]')

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -187,3 +187,30 @@ class TestEncodeComment(unittest.TestCase):
             "data": [["a,b,c"], ["a,b,c "]],
             "relation": "bla"}
         self.assertEqual(encoder.encode(my_arff), fixture)
+
+    def test_encode_adding_quotes_with_spaces(self):
+        # regression tests for https://github.com/renatopp/liac-arff/issues/87
+        encoder = self.get_encoder()
+
+        # \u3000 corresponds to an ideographic space. It should be treated as
+        # a space.
+        fixture = {
+            'relation': 'name',
+            'attributes': [('A', 'STRING'), ('B', 'STRING')],
+            'data': [['a', 'b'], ['b\u3000e', 'a']],
+        }
+        expected_data = """@RELATION name
+
+@ATTRIBUTE A STRING
+@ATTRIBUTE B STRING
+
+@DATA
+a,b
+'b　e',a
+"""
+        arff_data = encoder.encode(fixture)
+        self.assertEqual(arff_data, expected_data)
+
+        decoder = arff.ArffDecoder()
+        arff_object = decoder.decode(arff_data)
+        self.assertEqual(arff_object['data'], fixture['data'])

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -197,16 +197,16 @@ class TestEncodeComment(unittest.TestCase):
         fixture = {
             'relation': 'name',
             'attributes': [('A', 'STRING'), ('B', 'STRING')],
-            'data': [['a', 'b'], ['b\u3000e', 'a']],
+            'data': [[u'a', u'b'], [u'b\u3000e', u'a']],
         }
-        expected_data = """@RELATION name
+        expected_data = u"""@RELATION name
 
 @ATTRIBUTE A STRING
 @ATTRIBUTE B STRING
 
 @DATA
 a,b
-'b　e',a
+'b\u3000e',a
 """
         arff_data = encoder.encode(fixture)
         self.assertEqual(arff_data, expected_data)


### PR DESCRIPTION
closes #87 

Matches all possible separator spaces to add quotes.

NB: seen in a dataset with Japanese character with an ideographic space (`\u3000`)