### PR TITLE
Fix for Python 4

### DIFF
--- a/arff.py
+++ b/arff.py
@@ -304,7 +304,7 @@ _SUPPORTED_DATA_STRUCTURES = [DENSE, COO, LOD, DENSE_GEN, LOD_GEN]
 # =============================================================================
 
 # COMPATIBILITY WITH PYTHON 3 =================================================
-PY3 = sys.version_info[0] == 3
+PY3 = sys.version_info[0] >= 3
 if PY3:
     unicode = str
     basestring = str


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule).

There's some code which checks the Python major version is exactly 3:

```python
PY3 = sys.version_info[0] == 3
if PY3:
    # Python 3+ code

...

conversors = [ConversorStub(str if arff.PY3 else unicode),
              ConversorStub(float),
              ConversorStub(int),
              ConversorStub(str if arff.PY3 else unicode)]
```

When run on Python 4, this will run the Python 2 code! Instead, check the version is >= 3.

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./arff.py:307:7: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
```
