### PR TITLE
Travis CI: Update Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ matrix:
   include:
     - python: 2.7
     - python: 3.3
+      dist: trusty
     - python: 3.4
     - python: 3.5
     - python: 3.6
       env: DOCPUSH="true"
     - python: 3.7
-      dist: xenial
-      sudo: required
     - python: pypy
     - python: pypy3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     - python: 3.6
       env: DOCPUSH="true"
     - python: 3.7
+    - python: 3.8-dev
     - python: pypy
     - python: pypy3
 


### PR DESCRIPTION
Travis CI now defaults to Xenial, and Python 3.3 is only available on their Trusty images.

Both 3.3 and Trusty are EOL, so I'd recommend instead dropping support for it and 3.4. I've created another PR for this (https://github.com/renatopp/liac-arff/pull/100).

Also test on Python 3.8 beta. This is now on the final planned beta before release, and Guido is asking project maintainers to help test it:

* https://twitter.com/gvanrossum/status/1167659428142825474