### PR TITLE
Fix mypy errors

### DIFF
--- a/arff.py
+++ b/arff.py
@@ -319,7 +319,7 @@ if PY2:
 
 # EXCEPTIONS ==================================================================
 class ArffException(Exception):
-    message: Optional[str] = None
+    message = None  # type: Optional[str]
 
     def __init__(self):
         self.line = -1

--- a/arff.py
+++ b/arff.py
@@ -151,6 +151,7 @@ __version__ = '2.4.0'
 import re
 import sys
 import csv
+from typing import Optional
 
 # CONSTANTS ===================================================================
 _SIMPLE_TYPES = ['NUMERIC', 'REAL', 'INTEGER', 'STRING']
@@ -318,7 +319,7 @@ if PY2:
 
 # EXCEPTIONS ==================================================================
 class ArffException(Exception):
-    message = None
+    message: Optional[str] = None
 
     def __init__(self):
         self.line = -1


### PR DESCRIPTION
Fixes the following mypy errors,
```
mypy arff.py --ignore-missing-import           
arff.py:331: error: Incompatible types in assignment (expression has type "str", base class "ArffException" defined the type as "None")
arff.py:335: error: Incompatible types in assignment (expression has type "str", base class "ArffException" defined the type as "None")
arff.py:349: error: Incompatible types in assignment (expression has type "str", base class "ArffException" defined the type as "None")
arff.py:386: error: Incompatible types in assignment (expression has type "str", base class "ArffException" defined the type as "None")
arff.py:390: error: Incompatible types in assignment (expression has type "str", base class "ArffException" defined the type as "None")
arff.py:394: error: Incompatible types in assignment (expression has type "str", base class "ArffException" defined the type as "None")
Found 6 errors in 1 file (checked 1 source file)
```

Because scikit-learn vendors `arff.py` this error show also when running the checker on scikit-learn https://github.com/scikit-learn/scikit-learn/issues/12953

The goal here is by no mean to add type annotations for everything, but merely to fix mypy errors (that are fairly rare).